### PR TITLE
Addition of a Sed plugin.

### DIFF
--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -1,0 +1,41 @@
+var request = require('request');
+
+function handler(irc) {
+
+	irc.addCallBack(
+		'privmsg',
+		function(data) {
+			var regex = /s\/.+?\/.*?\/[gmixs]?/;
+
+			if(!regex.test(data.message)) {
+				return;
+			}
+
+			// Well it *looks* like a regex, now parse it.
+			engine = parseSed(data.message);
+
+			if(!engine.valid) {
+				// Oh no an error. Do something.
+			}
+
+			if(engine.type === 'DFA') {
+				// Use normal JS .replace stuff.
+			}
+			else {
+				// Try and do fancy backreferencing stuff.
+			}
+		}
+	);
+}
+
+function parseSed(msg) {
+
+	var engine = {
+		valid: false,
+		type: 'DFA',
+		search: '',
+		replace: '',
+		mods: '-i'
+	};
+
+}

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -1,6 +1,7 @@
 var request = require('request');
 
-module.data = {};
+var sedstack = { };
+var engine = { };
 
 function handler(irc) {
 
@@ -10,44 +11,75 @@ function handler(irc) {
 
 			addStack(data);
 
-			var regex = /^([a-zA-Z0-9^\\_{}\[\]\|`~^-]+\s?[:,~-]\s?)?s\/.+?\/.*?\/[gmixs]*?/;
+			var regex = /^([a-zA-Z0-9^\\_\{\}\[\]\|`~^-]+\s?[:,~-]\s?)?s\/.+?\/.*?\/[gmixs]*?/;
 
 			if(!regex.test(data.message)) {
 				return;
 			}
 
 			// Well it *looks* like a regex, now parse it.
-			engine = parseSed(data.message);
+			parseSed(data);
 
 			if(!engine.valid) {
 				// Oh no an error. Do something.
 			}
 
+			sedstack[ data.nickname ].pop(); // don't want the sed command on the stack.
+
 			if(engine.type === 'DFA') {
+				console.log("Nick: " + engine.nick);
 				// Use normal JS .replace stuff.
-				if( engine.nick in module.data ) {
-					var lines = module.data[ engine.nick ];
+				if( engine.nick in sedstack ) {
+					try {
+						engine.search = new RegExp(engine.search);
+					}
+					catch(err) {
+						irc.sendPrivMsg(data.channel, data.nickname + ": " + err);
+						return;
+					}
+
+					var lines = sedstack[ engine.nick ];
+					console.log(lines);
 					for(var i = lines.length; i > 0; i--) {
-						engine.msg = lines[i - 1]
+						engine.msg = lines[i - 1];
+						console.log("Testing: " + engine.msg);
+
+						var actiontest = /^\x01ACTION (.*?)\x01/.exec(engine.msg);
+						if(actiontest && actiontest.length > 0) {
+							engine.isAction = true;
+							engine.msg = actiontest[1];
+							console.log("result: " + engine.msg);
+						}
+						console.log("not an action");
+						
 						engine.result = engine.msg.replace(engine.search, engine.replace);
 						if(engine.result === engine.msg) {
 							// No change. Continue.
+							console.log("No change");
 							continue;
 						}
 						else {
 							// Found a Match.
 							engine.success = true;
+							console.log("Matched!");
+							if(engine.isAction) {
+								lines[i - 1] = "\x01ACTION " + engine.result + "\x01";
+							}
+							else {
+								lines[i - 1] = engine.result;
+							}
 							break;
 						}
 					}
 				}
 				else {
-					engine.err = "Sorry, " + data.nickname + ", I couldn't find any matches.";
+					engine.err = "Sorry, " + data.nickname + ", I couldn't find any data for " + engine.nick + ".";
 				}
 			}
 			else {
 				// Try and do fancy backreferencing stuff.
 				irc.sendPrivMsg(data.channel, "Lookbehind assertions will be supported soon.");
+				return;
 			}
 
 			if(!engine.err && engine.success) {
@@ -63,21 +95,25 @@ function handler(irc) {
 
 function addStack(data) {
 
-	if(data.nickname in module.data) {
-		module.data[ data.nickname ].push(data.message);
-		while(module.data[ data.nickname ].length > 100) {
-			module.data[ data.nickname ].shift();
+	//console.log(sedstack["ijz"][ sedstack["ijz"].length - 1 ]);
+
+	if(data.nickname in sedstack) {
+		sedstack[ data.nickname ].push(data.message);
+		while(sedstack[ data.nickname ].length > 100) {
+			sedstack[ data.nickname ].shift();
 		}
 	}
 	else {
-		module.data[ data.nickname ] = [ data.message ];
+		sedstack[ data.nickname ] = [ data.message ];
 	}
 
 }
 
 function parseSed(data) {
 
-	var engine = {
+	console.log("parseSed(): Nick: " + data.nickname);
+
+	engine = {
 		valid: false,
 		type: 'DFA',
                 nick: data.nickname,
@@ -95,9 +131,10 @@ function parseSed(data) {
 		reply: ''
 	};
 
-	var nickre = /^([a-zA-Z0-9^\\_{}\[\]\|`~^-]+\s?[:,~-]\s?)?s\//;
+	var nickre = /^([a-zA-Z0-9^\\_\{\}\[\]\|`~^-]+)\s?[:,~-]\s?s\//;
 	var groups = nickre.exec(data.message);
 	if(groups && groups.length > 0) {
+		console.log("Is this returning true?");
 		engine.nick = groups[1];
         }
 
@@ -106,11 +143,13 @@ function parseSed(data) {
 	}
 
 	var regex = /s\/(.+?)\/(.*?)\/([gmixs]*)?/;
-	var groups = regex.exec(data.message);
-	if(groups && groups.length > 0) {
-		engine.search = groups[1];
-		engine.replace = groups[2];
+	var capts = regex.exec(data.message);
+	if(capts && capts.length > 0) {
+		engine.search = capts[1];
+		engine.replace = capts[2];
 	}
+
+	console.log("parseSed(): Nick: " + engine.nick);
 
 	return engine;
 }
@@ -123,15 +162,17 @@ function makeReply(data, engine) {
 			+ engine.nick
 			+ ' meant: ';
 
-		if(engine.isAction) {
-			engine.reply += ' * '
-				+ engine.nick
-				+ ' ';
-		}
 	}
 	else {
 		engine.reply += data.nickname + ' meant: ';
 	}
+	
+	if(engine.isAction) {
+		engine.reply += '* '
+			+ engine.nick
+			+ ' ';
+	}
+
 	engine.reply += engine.result;
 }
 

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -64,6 +64,7 @@ function handler(irc) {
 							engine.isAction = true;
 							engine.msg = actiontest[1];
 						}
+
 						
 						engine.result = engine.msg.replace(engine.search, engine.replace);
 						if(engine.result === engine.msg) {
@@ -164,9 +165,10 @@ function parseSed(data, irc) {
 			proceed = true;
 		}
 		else if(expr.charAt(i) == '/') {
-			if (expr.charAt(i - 1) != '\\') {
+			if (expr.charAt(i - 1) != '\\' || (expr.charAt(i - 1) == '\\' && !proceed)) {
 				indices.push(i);
 			}
+			proceed = false;
 		}
 	}
 
@@ -185,7 +187,8 @@ function parseSed(data, irc) {
 				engine.replace = expr.slice(indices[index] + 1);
 			}
 			else { // Slice from after the index until before the next index.
-				engine.replace = expr.slice(indices[index] + 1, indices[index + 1]);
+				var tmp = expr.slice(indices[index] + 1, indices[index + 1]);
+				engine.replace = tmp.replace(/\\(\\|\/)/g, "$1");
 			}
 		}
 		else if(index == 0) {

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -1,11 +1,16 @@
 var request = require('request');
 
+module.data = {};
+
 function handler(irc) {
 
 	irc.addCallBack(
 		'privmsg',
 		function(data) {
-			var regex = /s\/.+?\/.*?\/[gmixs]?/;
+
+			addStack(data);
+
+			var regex = /^([a-zA-Z0-9^\\_{}\[\]\|`~^-]+\s?[:,~-]\s?)?s\/.+?\/.*?\/[gmixs]*?/;
 
 			if(!regex.test(data.message)) {
 				return;
@@ -20,22 +25,117 @@ function handler(irc) {
 
 			if(engine.type === 'DFA') {
 				// Use normal JS .replace stuff.
+				if( engine.nick in module.data ) {
+					var lines = module.data[ engine.nick ];
+					for(var i = lines.length; i > 0; i--) {
+						engine.msg = lines[i - 1]
+						engine.result = engine.msg.replace(engine.search, engine.replace);
+						if(engine.result === engine.msg) {
+							// No change. Continue.
+							continue;
+						}
+						else {
+							// Found a Match.
+							engine.success = true;
+							break;
+						}
+					}
+				}
+				else {
+					engine.err = "Sorry, " + data.nickname + ", I couldn't find any matches.";
+				}
 			}
 			else {
 				// Try and do fancy backreferencing stuff.
+				irc.sendPrivMsg(data.channel, "Lookbehind assertions will be supported soon.");
+			}
+
+			if(!engine.err && engine.success) {
+				makeReply(data, engine);
+				irc.sendPrivMsg(data.channel, engine.reply);
+			}
+			else {
+				irc.sendPrivMsg(data.channel, engine.err);
 			}
 		}
 	);
 }
 
-function parseSed(msg) {
+function addStack(data) {
+
+	if(data.nickname in module.data) {
+		module.data[ data.nickname ].push(data.message);
+		while(module.data[ data.nickname ].length > 100) {
+			module.data[ data.nickname ].shift();
+		}
+	}
+	else {
+		module.data[ data.nickname ] = [ data.message ];
+	}
+
+}
+
+function parseSed(data) {
 
 	var engine = {
 		valid: false,
 		type: 'DFA',
+                nick: data.nickname,
+                isAction: false,
+		msg: '',
 		search: '',
 		replace: '',
-		mods: '-i'
+		mods: '-i',
+                prematch: '',
+                match: '',
+                postmatch: '',
+                groups: [],
+		success: false,
+                result: '',
+		reply: ''
 	};
 
+	var nickre = /^([a-zA-Z0-9^\\_{}\[\]\|`~^-]+\s?[:,~-]\s?)?s\//;
+	var groups = nickre.exec(data.message);
+	if(groups && groups.length > 0) {
+		engine.nick = groups[1];
+        }
+
+	if(/\(\?<[^\)]+\)/.test(data.message)) {
+		engine.type = 'NFA';
+	}
+
+	var regex = /s\/(.+?)\/(.*?)\/([gmixs]*)?/;
+	var groups = regex.exec(data.message);
+	if(groups && groups.length > 0) {
+		engine.search = groups[1];
+		engine.replace = groups[2];
+	}
+
+	return engine;
 }
+
+function makeReply(data, engine) {
+
+	if(data.nickname !== engine.nick) {
+		engine.reply += data.nickname
+			+ ' thinks that '
+			+ engine.nick
+			+ ' meant: ';
+
+		if(engine.isAction) {
+			engine.reply += ' * '
+				+ engine.nick
+				+ ' ';
+		}
+	}
+	else {
+		engine.reply += data.nickname + ' meant: ';
+	}
+	engine.reply += engine.result;
+}
+
+module.exports = function(module_holder) {
+    module_holder['sed'] = handler;
+};
+

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -27,7 +27,7 @@ function handler(irc) {
 
 			addStack(data);
 
-			var regex = /^([a-zA-Z0-9^\\_\{\}\[\]\|`~^-]+\s?[:,~-]\s?)?s\/.+?\/.*?\/[gmixs]*?/;
+			var regex = /^([a-zA-Z0-9^\\_\{\}\[\]\|`~^-]+\s?[:,~-]\s?)?s\/.+?\/.*?(\/[gi]*)?/;
 
 			if(!regex.test(data.message)) {
 				return;
@@ -182,14 +182,16 @@ function parseSed(data, irc) {
 			}
 		}
 		else if(index == 1) {
+			var tmp;
 			if(indices.length < 3) { // i.e. there's no final / to terminate the sed.
 				// Slice from after the index to the end.
-				engine.replace = expr.slice(indices[index] + 1);
+				tmp = expr.slice(indices[index] + 1);
 			}
 			else { // Slice from after the index until before the next index.
-				var tmp = expr.slice(indices[index] + 1, indices[index + 1]);
-				engine.replace = tmp.replace(/\\(\\|\/)/g, "$1");
+				tmp = expr.slice(indices[index] + 1, indices[index + 1]);
 			}
+
+			engine.replace = tmp.replace(/\\(\\|\/)/g, "$1");
 		}
 		else if(index == 0) {
 			engine.search = expr.slice(indices[index] + 1, indices[index + 1]);

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -48,7 +48,13 @@ function handler(irc) {
 				// Use normal JS .replace stuff.
 				if( engine.nick in sedstack ) {
 					try {
-						engine.search = new RegExp(engine.search);
+						if(engine.mod) {
+							engine.search = new RegExp(engine.search, engine.mod);
+						}
+						else {
+							engine.search = new RegExp(engine.search);
+						}
+						console.log("regex: " + engine.search.toString());
 					}
 					catch(err) {
 						irc.sendPrivMsg(data.channel, data.nickname + ": " + err);
@@ -180,6 +186,7 @@ function parseSed(data, irc) {
 				engine.valid = false;
 				return;
 			}
+			console.log("Woo we have mods: " + engine.mod);
 		}
 		else if(index == 1) {
 			var tmp;

--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -54,7 +54,6 @@ function handler(irc) {
 						else {
 							engine.search = new RegExp(engine.search);
 						}
-						console.log("regex: " + engine.search.toString());
 					}
 					catch(err) {
 						irc.sendPrivMsg(data.channel, data.nickname + ": " + err);
@@ -186,7 +185,6 @@ function parseSed(data, irc) {
 				engine.valid = false;
 				return;
 			}
-			console.log("Woo we have mods: " + engine.mod);
 		}
 		else if(index == 1) {
 			var tmp;

--- a/extensions/test.js
+++ b/extensions/test.js
@@ -15,7 +15,7 @@ function handler(irc) {
 
 				lipsum.getText(
 					function(text) {
-						irc.sendPrivMsg('#xetk', text);
+						irc.sendPrivMsg(data.channel, text);
 					}, 
 					lipsumOpts
 				);


### PR DESCRIPTION
Supports all DFA compatible regular expressions, with g and i (global and case-insensitive) modifiers.

Lookbehind assertions [i.e.: (?<=...) and ( ?<!...)] are irregular and require a NFA engine, which I haven't implemented yet.

I also changed "#xetk" to "data.channel" in the test plugin, to ensure consistency.