### PR TITLE
Sed 0.2

### DIFF
--- a/extensions/sed.js
+++ b/extensions/sed.js
@@ -172,7 +172,6 @@ function parseSed(data, irc) {
 			proceed = false;
 		}
 	}
-	console.log("Number of indices: " + indices.length);
 
 	// Populate engine.search, engine.replace, and engine.mods using the indices array.
 	for(var index = 0; index < indices.length; index++) {


### PR DESCRIPTION
Fixed a bug whereby JS ended up trying to compile invalid regex modifiers into a RegExp object.

Invalid modifiers are now ignored, and the sed expression evaluated as if there were no modifiers.